### PR TITLE
fix: Update toolchain channel version to latest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "london-pi-tube2"
+name = "london-pi-tube"
 version = "0.1.0"
 edition = "2024"
 license = "MIT or Apache-2.0"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.92"
+channel = "1.97"
 components = ["rust-src", "rustfmt", "llvm-tools"]
 targets = ["thumbv8m.main-none-eabihf"]


### PR DESCRIPTION
Bump toolchain channel version to latest to ensure rust-analyzer VS Code extension is functional.

This also corrects the package name.